### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,7 +2,7 @@
 
 [[https://travis-ci.org/paetzke/consolor][https://travis-ci.org/paetzke/consolor.png?branch=master]]
 [[https://coveralls.io/r/paetzke/consolor?branch=master][https://coveralls.io/repos/paetzke/consolor/badge.png?branch=master]]
-[[https://pypi.python.org/pypi/consolor/][https://pypip.in/v/consolor/badge.png]]
+[[https://pypi.python.org/pypi/consolor/][https://img.shields.io/pypi/v/consolor.svg]]
 
 Consolor provides highlighting functions for terminals.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20consolor))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `consolor`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.